### PR TITLE
Open contributors list formatted instead of raw

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
                                             <li>Noémie Lehuby</li>
                                             <li>Poilou</li>
                                             <li>Maxime Corteel</li>
-                                            <li><a href="/contributors.md" target="_blank" data-l10n-id="modal_about_category_contributors_list">...</a></li>
+                                            <li><a href="https://github.com/OpenBeerMap/OpenBeerMap.github.io/blob/master/contributors.md#contributors" target="_blank" data-l10n-id="modal_about_category_contributors_list">...</a></li>
                                         </ul>
                                     </div>
                                 </div>


### PR DESCRIPTION
In Firefox, it offers the .md file for download.